### PR TITLE
Fix formatting in "Craft a Hearth" quest

### DIFF
--- a/config/ftbquests/quests/chapters/thin_air__cold_sweat.snbt
+++ b/config/ftbquests/quests/chapters/thin_air__cold_sweat.snbt
@@ -526,14 +526,11 @@
 		}
 		{
 			description: [
-				"To function properly, it must be under a roof and maintained with the appropriate fuel; in cold situations, this would be hot items like &fCoal and Lava&, and in hot situations this would be cold items like &fSnowballs, Water, and Ice&r.&r"
+				"To function properly, it must be under a roof and maintained with the appropriate fuel; in cold situations, this would be hot items like &fCoal and Lava&r, and in hot situations this would be cold items like &fSnowballs, Water, and Ice&r."
 				""
-				"Be aware of its &4&l20-block radius&r when deciding where to place the &c&lhearth&r, as anything outside of its range will not be safe, even if is is within the bounds of the structure the &c&lHearth&r is placed in. It is possible to use multiple &c&lHearths&r in tandem, however, so it is possible to regulate large bases."
+				"Be aware of its &4&l20-block radius&r when deciding where to place the &c&lHearth&r, as anything outside of its range will not be safe, even if is is within the bounds of the structure the &c&lHearth&r is placed in. It is possible to use multiple &c&lHearths&r in tandem, however, so it is possible to regulate large bases."
 				""
-				"Upon initial placement and fueling, the &c&lHearth&r will begin to "
-				"warm"
-				"up"
-				", gradually giving nearby players higher levels of the &6&lInsulated&r effect before reaching its maximum level (&6&l10&r). Players with the &6&lInsulated&r effect will experience less extreme temperatures depending on the level of the effect. When a player leaves the &c&lHearth&r's radius, they are once again exposed to the elements after the &6&lInsulated&r effect has expired."
+				"Upon initial placement and fueling, the &c&lHearth&r will begin to warm up, gradually giving nearby players higher levels of the &6&lInsulated&r effect before reaching its maximum level (&6&l10&r). Players with the &6&lInsulated&r effect will experience less extreme temperatures depending on the level of the effect. When a player leaves the &c&lHearth&r's radius, they are once again exposed to the elements after the &6&lInsulated&r effect has expired."
 			]
 			id: "558BB6BD94C602B3"
 			rewards: [
@@ -548,7 +545,7 @@
 					type: "item"
 				}
 			]
-			subtitle: "In a more permanent solution, like a base or outpost, a &c&lhearth&r is a more apt solution to stave off the elements. In the long run, it is much less &2&loperate&r and does not have to be constantly monitored."
+			subtitle: "In a more permanent solution, like a base or outpost, a &c&lHearth&r is a more apt solution to stave off the elements. In the long run, it is much less to &2&loperate&r and does not have to be constantly monitored."
 			tasks: [{
 				id: "64B9040AFC49B0BC"
 				item: "cold_sweat:hearth"


### PR DESCRIPTION
Fixes #113. While I was in there, in addition to fixing the error, I also just consistently made it "Hearth" (upper case) and did some minor spelling/grammar/formatting corrections.

After fix:
![image](https://github.com/LunaPixelStudios/SteamPunk/assets/767490/0509efcf-7132-4bdf-912c-b0c48811e036)
